### PR TITLE
fix : 복권 긁은 후 결과 반영 바로 안 되는 버그 해결

### DIFF
--- a/src/page/Game/Components/Lotto.jsx
+++ b/src/page/Game/Components/Lotto.jsx
@@ -239,6 +239,7 @@ const Lotto = ({ member, gameInfo, updateInfo }) => {
         })
         .then((data) => {
           if (data.success) {
+            setMemberPoint(data.data.point);
             const token = member.token;
             const memberInfo = data.data;
             updateInfo({ token, memberInfo });


### PR DESCRIPTION
- 보유포인트를 업데이트 안시켜줘서 발생하는 버그였다.

#262