### PR TITLE
CTF 새탭으로 페이지 링크 열리도록 #283

### DIFF
--- a/src/page/CTF/Components/ChallengeModal.jsx
+++ b/src/page/CTF/Components/ChallengeModal.jsx
@@ -138,6 +138,9 @@ const ChallengeModal = forwardRef(({ detailProbList, member }, ref) => {
                           /* change={detailProbList.content} */
                           theme={isDark ? 'dark' : 'light'}
                           height="100%"
+                          linkAttributes={{
+                            target: '_blank',
+                          }}
                           /* ref={viewerRef} */
                         />
                       </div>

--- a/src/shared/Component/HeaderPopDown.jsx
+++ b/src/shared/Component/HeaderPopDown.jsx
@@ -46,6 +46,7 @@ const PopDown = ({ category, member, initialize }) => {
                         <a
                           key={index}
                           href={item.href}
+                          target="_blank"
                           className="-m-3 p-3 flex items-start rounded-lg hover:bg-pointYellow"
                           onClick={() => {
                             initialize();

--- a/src/shared/category.js
+++ b/src/shared/category.js
@@ -22,6 +22,7 @@ const categoriesAll = [
         name: 'CTF',
         href: 'ctf',
         auth: null,
+        external: true,
       },
       {
         id: null,

--- a/src/shared/category.js
+++ b/src/shared/category.js
@@ -22,7 +22,6 @@ const categoriesAll = [
         name: 'CTF',
         href: 'ctf',
         auth: null,
-        external: true,
       },
       {
         id: null,


### PR DESCRIPTION
- CTF + 키퍼위키도 새탭으로 열리게
- 기존 키퍼위키처럼 카테고리 속성에 external: true를 둠.
-  external: true를 갖는것들을 새탭으로 열리게 처리
- #283