### PR TITLE
ctf 글자 overflow 처리 #285

### DIFF
--- a/src/page/CTF/Components/ChallengeCard.jsx
+++ b/src/page/CTF/Components/ChallengeCard.jsx
@@ -62,8 +62,8 @@ const ChallengeCard = (props) => {
         }
       >
         <div className="my-3">
-          <div className="text-xl m-3 font-semibold">{title}</div>
-          <div>{score}</div>
+          <div className="text-xl m-3 font-semibold truncate">{title}</div>
+          <div className="truncate">{score}</div>
         </div>
       </button>
 

--- a/src/page/CTF/Components/ChallengeModal.jsx
+++ b/src/page/CTF/Components/ChallengeModal.jsx
@@ -12,7 +12,7 @@ import { DownloadIcon, XIcon } from '@heroicons/react/outline';
 import '@toast-ui/editor/dist/toastui-editor.css'; //마크다운 편집기 뷰어 에디터
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
 import { Viewer } from '@toast-ui/react-editor';
-
+import Marquee from 'react-fast-marquee';
 // API
 import ctfAPI from 'API/v1/ctf';
 
@@ -125,8 +125,15 @@ const ChallengeModal = forwardRef(({ detailProbList, member }, ref) => {
                       </button>
                     </div>
 
-                    <Dialog.Title className="text-center text-xl font-medium text-gray-900 leading-loose m-8">
-                      {detailProbList.title}
+                    <Dialog.Title className="truncate text-center text-xl font-medium text-gray-900 leading-loose m-8">
+                      <Marquee
+                        gradient={false}
+                        speed={10}
+                        className="text-black"
+                      >
+                        {detailProbList.title}
+                      </Marquee>
+
                       <br />
                       {detailProbList.score}
                     </Dialog.Title>

--- a/src/page/CTF/Components/ContestOverview.jsx
+++ b/src/page/CTF/Components/ContestOverview.jsx
@@ -41,9 +41,9 @@ const ContestOverview = (props) => {
         onClick={handleChange}
       >
         <div className="my-3">
-          <div className="text-xl m-4 truncate">{name}</div>
-          <div className="truncate">{description}</div>
-          <div className="truncate">{creator}</div>
+          <div className="text-xl m-2 truncate px-4">{name}</div>
+          <div className="truncate px-4">{description}</div>
+          <div className="truncate px-4">{creator}</div>
         </div>
       </button>
     </>

--- a/src/page/CTF/Components/ContestOverview.jsx
+++ b/src/page/CTF/Components/ContestOverview.jsx
@@ -41,9 +41,9 @@ const ContestOverview = (props) => {
         onClick={handleChange}
       >
         <div className="my-3">
-          <div className="text-xl m-4">{name}</div>
-          <div>{description}</div>
-          <div>{creator}</div>
+          <div className="text-xl m-4 truncate">{name}</div>
+          <div className="truncate">{description}</div>
+          <div className="truncate">{creator}</div>
         </div>
       </button>
     </>

--- a/src/page/CTF/Components/ContestTable.jsx
+++ b/src/page/CTF/Components/ContestTable.jsx
@@ -38,9 +38,9 @@ const ContestTable = (props) => {
         onClick={handleChange}
         className="w-full h-10 hover:bg-gray-100 dark:hover:bg-[#0b1523] bg-white dark:text-white dark:bg-darkPoint cursor-pointer"
       >
-        <td>{name}</td>
-        <td>{description}</td>
-        <td>{creator}</td>
+        <td className="w-1/3 truncate">{name}</td>
+        <td className="w-1/3 truncate">{description}</td>
+        <td className="w-1/3 truncate">{creator}</td>
       </tr>
     </>
   );

--- a/src/page/CTF/Components/ContestTable.jsx
+++ b/src/page/CTF/Components/ContestTable.jsx
@@ -38,9 +38,9 @@ const ContestTable = (props) => {
         onClick={handleChange}
         className="w-full h-10 hover:bg-gray-100 dark:hover:bg-[#0b1523] bg-white dark:text-white dark:bg-darkPoint cursor-pointer"
       >
-        <td className="w-1/3 truncate">{name}</td>
-        <td className="w-1/3 truncate">{description}</td>
-        <td className="w-1/3 truncate">{creator}</td>
+        <td className="w-1/3 truncate px-4">{name}</td>
+        <td className="w-1/3 truncate px-4">{description}</td>
+        <td className="w-1/3 truncate px-4">{creator}</td>
       </tr>
     </>
   );

--- a/src/page/CTF/Components/NavigationLayout.jsx
+++ b/src/page/CTF/Components/NavigationLayout.jsx
@@ -105,13 +105,13 @@ const NavigationLayout = ({ isDark, member, ctfId, ctfName, ctfTeamName }) => {
   const cancelButtonRef = useRef();
 
   const ctfNameView1 = (
-    <div className="absolute inset-x-0 bottom-5 mx-5 px-5 items-center py-3 font-bold rounded-md border-2 border-mainYellow text-mainYellow text-center bg-amber-100 dark:bg-opacity-20  ">
+    <div className="truncate absolute inset-x-0 bottom-5 mx-5 px-5 items-center py-3 font-bold rounded-md border-2 border-mainYellow text-mainYellow text-center bg-amber-100 dark:bg-opacity-20  ">
       {ctfName}
     </div>
   );
 
   const ctfNameView2 = (
-    <div className="bottom-full mx-5 px-5 items-center py-3 font-bold rounded-md border-2 border-mainYellow text-mainYellow text-center bg-amber-100 dark:bg-opacity-20  ">
+    <div className="truncate bottom-full mx-5 px-5 items-center py-3 font-bold rounded-md border-2 border-mainYellow text-mainYellow text-center bg-amber-100 dark:bg-opacity-20  ">
       {ctfName}
     </div>
   );

--- a/src/page/CTF/Components/ScoreBoardRank.jsx
+++ b/src/page/CTF/Components/ScoreBoardRank.jsx
@@ -35,7 +35,7 @@ const ScoreBoardRank = ({ state, rankList }) => {
   };
 
   return (
-    <table className="h-auto w-full lg:w-3/5 text-left bg-white dark:text-white dark:bg-darkPoint">
+    <table className="table-fixed h-auto w-full lg:w-3/5 text-left bg-white dark:text-white dark:bg-darkPoint">
       <thead>
         <tr className="h-10 w-full bg-gradient-to-r from-amber-400 via-red-800 to-black dark:from-pink-300 dark:via-purple-400 dark:to-indigo-400  text-lg text-white font-extrabold text-center ">
           <th className="w-1/12 text-left"></th>
@@ -52,7 +52,7 @@ const ScoreBoardRank = ({ state, rankList }) => {
             className="h-12 w-full hover:bg-gray-100 dark:hover:bg-slate-700   "
           >
             {/* shadow shadow-purple-300 */}
-            <td className="h-12">
+            <td className="h-12 w-1/12 truncate">
               {info.rank === 1 ? (
                 <img
                   className="h-10"
@@ -78,9 +78,14 @@ const ScoreBoardRank = ({ state, rankList }) => {
                 ''
               )}
             </td>
-            <td>{info.rank}</td>
-            <td onClick={() => clickTeamHandler(info)}>{info.name}</td>
-            <td>
+            <td className="w-2/12 truncate">{info.rank}</td>
+            <td
+              className="w-5/12 truncate"
+              onClick={() => clickTeamHandler(info)}
+            >
+              {info.name}
+            </td>
+            <td className="w-4/12 truncate">
               <StarIcon className="inline-block h-6 w-6 m-1 text-amber-400 dark:text-purple-300" />
               {info.score}
             </td>

--- a/src/page/CTF/Ctf.jsx
+++ b/src/page/CTF/Ctf.jsx
@@ -66,7 +66,7 @@ const Ctf = ({ member }) => {
               </div>
               <div className="w-full">
                 <div className="w-full h-full inline-block rounded overflow-hidden text-center">
-                  <table className="w-full shadow bg-white">
+                  <table className="w-full shadow table-fixed bg-white">
                     <thead>
                       <tr className="h-10 w-full bg-gradient-to-r from-amber-400 via-red-800 to-black dark:from-pink-300 dark:via-purple-400 dark:to-indigo-400  text-lg text-white font-extrabold text-center ">
                         {tableHead.map((head, headIdx) => (

--- a/src/page/CTF/Team.jsx
+++ b/src/page/CTF/Team.jsx
@@ -4,6 +4,7 @@ import Modal from 'react-awesome-modal';
 import Button from '@material-ui/core/Button';
 import actionCtf from 'redux/action/ctf';
 import { Link, useNavigate } from 'react-router-dom';
+import Marquee from 'react-fast-marquee';
 // API
 import teamAPI from 'API/v1/ctf';
 
@@ -144,8 +145,21 @@ const Team = ({ member, ctfId, updateCtfTeamName }) => {
     return (
       <>
         <div className="pt-12 text-center grid grid-cols-1 content-center dark:text-white">
-          <div className="text-5xl m-2 font-extrabold">{teamName}</div>
-          <div className="text-2xl">{teamDes}</div>
+          {/* <div className="text-5xl m-2 font-extrabold truncate">{teamName}</div> */}
+          {teamName?.length > 20 ? (
+            <Marquee
+              gradient={false}
+              speed={10}
+              className="text-5xl m-2 font-extrabold truncate"
+            >
+              {teamName}
+            </Marquee>
+          ) : (
+            <div className="text-5xl m-2 font-extrabold truncate">
+              {teamName}
+            </div>
+          )}
+          <div className="text-2xl ">{teamDes}</div>
           <div>{teamScore} points</div>
         </div>
         <div className="flex justify-center m-2">

--- a/src/page/CTF/Team.jsx
+++ b/src/page/CTF/Team.jsx
@@ -198,7 +198,7 @@ const Team = ({ member, ctfId, updateCtfTeamName }) => {
           Solves
         </strong>
         <div className="flex flex-col items-center rounded overflow-hidden m-4 p-2">
-          <table className="justify-center dark:text-white w-11/12 border-2 shadow  rounded-md dark:bg-darkPoint">
+          <table className="table-fixed justify-center dark:text-white w-11/12 border-2 shadow  rounded-md dark:bg-darkPoint">
             <thead>
               <tr className="rounded w-10/12 h-10 bg-gray-100 text-lg text-black">
                 <th>Type</th>
@@ -213,9 +213,9 @@ const Team = ({ member, ctfId, updateCtfTeamName }) => {
                     key={idx}
                     className="w-11/12 h-10 text-center hover:bg-gray-100 dark:hover:bg-[#0b1523]"
                   >
-                    <td>{info.category.name}</td>
-                    <td>{info.title}</td>
-                    <td>{info.score}</td>
+                    <td className="w-1/3 truncate">{info.category.name}</td>
+                    <td className="w-1/3 truncate">{info.title}</td>
+                    <td className="w-1/3 truncate">{info.score}</td>
                   </tr>
                 );
               })}

--- a/src/page/CTF/admin/ChallengeAdmin.jsx
+++ b/src/page/CTF/admin/ChallengeAdmin.jsx
@@ -179,7 +179,7 @@ const ChallengeAdmin = ({ member, ctfId }) => {
           <div className="p-[2px] mb-2 dark:from-purple-500 dark:via-purple-200 dark:to-amner-200 bg-gradient-to-r from-amber-500 via-amber-200 to-yellow-300  "></div>
 
           <div className="w-full  flex rounded">
-            <table className="text-center h-full w-full bg-white dark:text-white dark:bg-darkPoint">
+            <table className="table-fixed text-center h-full w-full bg-white dark:text-white dark:bg-darkPoint">
               <thead>
                 <tr className=" h-10 w-full bg-gradient-to-r from-amber-400 via-red-800 to-black dark:from-pink-300 dark:via-purple-400 dark:to-indigo-400  text-lg text-white font-extrabold text-center ">
                   <th className="w-2/12">문제</th>
@@ -196,19 +196,19 @@ const ChallengeAdmin = ({ member, ctfId }) => {
                 {rankList.map((info) => (
                   <tr key={info.challengeId} className="h-10 w-full  ">
                     {/* shadow shadow-purple-300 */}
-                    <td>{info.title}</td>
-                    <td>{info.category.name}</td>
-                    <td>{info.flag}</td>
-                    <td>{info.creatorName}</td>
-                    <td>{info.score}</td>
+                    <td className="w-2/12 truncate">{info.title}</td>
+                    <td className="w-2/12 truncate">{info.category.name}</td>
+                    <td className="w-4/12 truncate">{info.flag}</td>
+                    <td className="w-1/12 truncate">{info.creatorName}</td>
+                    <td className="w-1/12 truncate">{info.score}</td>
 
-                    <td className="dark:text-black">
+                    <td className="w-1/12 truncate dark:text-black">
                       <ProbOpenCloseBtn
                         isSolvable={info.isSolvable}
                         challengeId={info.challengeId}
                       />
                     </td>
-                    <td>
+                    <td className="w-1/12 truncate">
                       <DeleteBtn
                         challengeId={info.challengeId}
                         checkedItemHandler={checkedItemHandler}

--- a/src/page/CTF/admin/Submissions.jsx
+++ b/src/page/CTF/admin/Submissions.jsx
@@ -64,8 +64,8 @@ const Submissions = ({ member, ctfId }) => {
               <div className="p-[2px] mb-2 dark:from-purple-500 dark:via-purple-200 dark:to-amner-200 bg-gradient-to-r from-amber-500 via-amber-200 to-yellow-300  "></div>
               {/* 2.  프로필 이미지 + 팔로우 + 포인트 */}
 
-              <div className="w-full h-1/12 flex rounded overflow-auto">
-                <table className="text-center h-full w-full bg-white dark:text-white dark:bg-darkPoint">
+              <div className="w-full h-1/12 flex rounded ">
+                <table className="table-fixed  text-center h-full w-full bg-white dark:text-white dark:bg-darkPoint">
                   <thead>
                     <tr className=" h-10 w-full bg-gradient-to-r from-amber-400 via-red-800 to-black dark:from-pink-300 dark:via-purple-400 dark:to-indigo-400  text-lg text-white font-extrabold text-center ">
                       <th className="w-2/12">문제</th>
@@ -80,10 +80,9 @@ const Submissions = ({ member, ctfId }) => {
                   <tbody className="">
                     {rankList.map((info) => (
                       <tr key={info.id} className="h-10 w-full  ">
-                        {/* shadow shadow-purple-300 */}
-                        <td>{info.challengeName}</td>
-                        <td>{info.flagSubmitted}</td>
-                        <td>
+                        <td className="w-2/12 truncate">{info.challengeName}</td>
+                        <td className="w-1/12 truncate">{info.flagSubmitted}</td>
+                        <td className="w-1/12 truncate">
                           {' '}
                           {info.isCorrect === true ? (
                             <div className="bg-green-200 w-full rounded-md mx-1 dark:text-black">
@@ -96,9 +95,9 @@ const Submissions = ({ member, ctfId }) => {
                           )}
                         </td>
 
-                        <td>{info.teamName}</td>
-                        <td>{info.submitterRealname}</td>
-                        <td>{info.submitTime}</td>
+                        <td className="w-1/12 truncate">{info.teamName}</td>
+                        <td className="w-1/12 truncate">{info.submitterRealname}</td>
+                        <td className="w-4/12 truncate">{info.submitTime}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/src/page/ItManager/Admin/EditModal.jsx
+++ b/src/page/ItManager/Admin/EditModal.jsx
@@ -128,7 +128,7 @@ const EditModal = forwardRef(
                         onClick={closeModal}
                         className={
                           isDark
-                            ? 'bg-white w-24 hover:bg-slate-100 cursor-pointer rounded-lg p-2'
+                            ? '  truncate bg-white w-24 hover:bg-slate-100 cursor-pointer rounded-lg p-2'
                             : 'bg-darkPoint w-24 hover:bg-black cursor-pointer rounded-lg p-2'
                         }
                       >


### PR DESCRIPTION
- ctf메인 페이지 - 대회 이름, 설명 overflow처리
- ctf 챌린지 페이지 - 카드(문제 이름) oveflow처리
- ctf 챌린지 페이지 - 모달창 문제이름 글자 흐르도록 처리
- 스코어보드 페이지 - 테이블 overflow처리
- ctf 팀 페이지 -  solves 테이블 overflow처리
- 문제관리 페이지 - 테이블 overflow처리
- 제출로그 페이지 - 테이블 overflow처리
- 대회운영 페이지 - 백엔드상에서 글자제한을 이미 막아놓음
- 네비게이션 팀이름 overflow처리
- #285