### PR TITLE
Feature/페이지 블럭 타이틀 수정 기능 #288

### DIFF
--- a/src/API/v1/about.js
+++ b/src/API/v1/about.js
@@ -37,6 +37,23 @@ async function tmp({
   }
 }
 
+async function changeTitle({ id, title, type, token }) {
+  const options = {
+    method: 'PUT',
+    url: API_URL + '/v1/admin/about/titles/' + id,
+    headers: {
+      Authorization: token,
+    },
+    data: { title , type },
+  };
+  try {
+    const response = await axios(options);
+    return response.data;
+  } catch (error) {
+    return error.response.data;
+  }
+}
+
 async function getIntroInfo() {
   const options = {
     method: 'GET',
@@ -89,10 +106,12 @@ async function getHistoryInfo() {
   }
 }
 
+
 export default {
   getIntroInfo,
   getActivityInfo,
   getExcellenceInfo,
   getHistoryInfo,
+  changeTitle,
   tmp,
 };

--- a/src/page/About/Component/Activity.jsx
+++ b/src/page/About/Component/Activity.jsx
@@ -150,7 +150,7 @@ const Activity = ({ member }) => {
         setActivityInfo(data.list);
       }
     });
-  }, [activityInfo]);
+  }, []);
 
   const editTitle = () => {
     setNewTitle(activityInfo[0].title);
@@ -162,7 +162,13 @@ const Activity = ({ member }) => {
           type: 'activity',
           token: token,
         })
-        .then((res) => {});
+        .then((res) => {
+          aboutAPI.getActivityInfo().then((data) => {
+            if (data.success) {
+              setActivityInfo(data.list);
+            }
+          });
+        });
     }
     setEditTitleMode(!editTitleMode);
   };

--- a/src/page/About/Component/Activity.jsx
+++ b/src/page/About/Component/Activity.jsx
@@ -163,11 +163,7 @@ const Activity = ({ member }) => {
           token: token,
         })
         .then((res) => {
-          aboutAPI.getActivityInfo().then((data) => {
-            if (data.success) {
-              setActivityInfo(data.list);
-            }
-          });
+          setActivityInfo([res.data]);
         });
     }
     setEditTitleMode(!editTitleMode);

--- a/src/page/About/Component/Activity.jsx
+++ b/src/page/About/Component/Activity.jsx
@@ -188,17 +188,16 @@ const Activity = ({ member }) => {
       {/* TODO 여기까지 지울 거 */}
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="py-6 lg:py-10 px-3 md:px-12 lg:px-16">
-          {!editTitleMode && (
-            <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow inline-block">
-              {activityInfo[0].title}
-            </h2>
-          )}
-          {editTitleMode && (
+          {editTitleMode ? (
             <input
               className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
               onChange={inputNewTitle}
               value={newTitle}
             />
+          ) : (
+            <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow inline-block">
+              {activityInfo[0].title}
+            </h2>
           )}
           {adminFlag && (
             <button

--- a/src/page/About/Component/Activity.jsx
+++ b/src/page/About/Component/Activity.jsx
@@ -64,7 +64,7 @@ function classNames(...classes) {
 
 const Activity = ({ member }) => {
   const [adminFlag, setAdminFlag] = useState(false);
-  const [editTitleMode, setEditTitleMode] = useState(false);
+  const [isTitleEditMode, setIsTitleEditMode] = useState(false);
   const [newTitle, setNewTitle] = useState();
   const token = member.token;
   const [activityInfo, setActivityInfo] = useState([
@@ -154,7 +154,7 @@ const Activity = ({ member }) => {
 
   const editTitle = () => {
     setNewTitle(activityInfo[0].title);
-    if (editTitleMode) {
+    if (isTitleEditMode) {
       aboutAPI
         .changeTitle({
           id: activityInfo[0].id,
@@ -166,7 +166,7 @@ const Activity = ({ member }) => {
           setActivityInfo([res.data]);
         });
     }
-    setEditTitleMode(!editTitleMode);
+    setIsTitleEditMode(!isTitleEditMode);
   };
 
   const inputNewTitle = (e) => {
@@ -190,7 +190,7 @@ const Activity = ({ member }) => {
       {/* TODO 여기까지 지울 거 */}
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="py-6 lg:py-10 px-3 md:px-12 lg:px-16">
-          {editTitleMode ? (
+          {isTitleEditMode ? (
             <input
               className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
               onChange={inputNewTitle}
@@ -206,7 +206,7 @@ const Activity = ({ member }) => {
               className="text-xs text-gray-500 underline inline-block ml-2 align-top"
               onClick={editTitle}
             >
-              {editTitleMode ? '확인' : '수정'}
+              {isTitleEditMode ? '확인' : '수정'}
             </button>
           )}
           <div className="px-2 lg:px-4 space-y-16 text-black dark:text-white">

--- a/src/page/About/Component/Activity.jsx
+++ b/src/page/About/Component/Activity.jsx
@@ -63,9 +63,10 @@ function classNames(...classes) {
 }
 
 const Activity = ({ member }) => {
-  /* TODO 여기부터 지울 거 */
   const [adminFlag, setAdminFlag] = useState(false);
-  /* TODO 여기까지 지울 거 */
+  const [editTitleMode, setEditTitleMode] = useState(false);
+  const [newTitle, setNewTitle] = useState();
+  const token = member.token;
   const [activityInfo, setActivityInfo] = useState([
     {
       id: null,
@@ -93,6 +94,7 @@ const Activity = ({ member }) => {
 
   /* TODO 여기부터 지울 거 */
 
+  const titleInput = useRef();
   const inputRef = useRef(null);
 
   useEffect(() => {
@@ -150,7 +152,29 @@ const Activity = ({ member }) => {
         setActivityInfo(data.list);
       }
     });
-  }, []);
+  }, [activityInfo]);
+
+  const sectionTitle = activityInfo[0].title;
+
+  const editTitle = () => {
+    setNewTitle(activityInfo[0].title);
+    if (editTitleMode) {
+      aboutAPI
+        .changeTitle({
+          id: activityInfo[0].id,
+          title: newTitle,
+          type: 'activity',
+          token: token,
+        })
+        .then((res) => {});
+    }
+    setEditTitleMode(!editTitleMode);
+  };
+
+  const inputNewTitle = (e) => {
+    setNewTitle(e.target.value);
+  };
+
   return (
     <div className="">
       {/* TODO 여기부터 지울 거 */}
@@ -168,9 +192,29 @@ const Activity = ({ member }) => {
       {/* TODO 여기까지 지울 거 */}
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="py-6 lg:py-10 px-3 md:px-12 lg:px-16">
-          <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow">
-            {activityInfo[0].title}
-          </h2>
+          {!editTitleMode && (
+            <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow inline-block">
+              {activityInfo[0].title}
+            </h2>
+          )}
+          {editTitleMode && (
+            <input
+              className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
+              onChange={inputNewTitle}
+              value={newTitle}
+              ref={titleInput}
+            />
+          )}
+          {adminFlag && (
+            <>
+              <button
+                className="text-xs text-gray-500 underline inline-block ml-2 align-top"
+                onClick={editTitle}
+              >
+                {editTitleMode ? '확인' : '수정'}
+              </button>
+            </>
+          )}
           <div className="px-2 lg:px-4 space-y-16 text-black dark:text-white">
             {activityInfo[0].subtitleImageResults.map((article, articleIdx) => (
               <div

--- a/src/page/About/Component/Activity.jsx
+++ b/src/page/About/Component/Activity.jsx
@@ -93,8 +93,6 @@ const Activity = ({ member }) => {
   ]);
 
   /* TODO 여기부터 지울 거 */
-
-  const titleInput = useRef();
   const inputRef = useRef(null);
 
   useEffect(() => {
@@ -154,8 +152,6 @@ const Activity = ({ member }) => {
     });
   }, [activityInfo]);
 
-  const sectionTitle = activityInfo[0].title;
-
   const editTitle = () => {
     setNewTitle(activityInfo[0].title);
     if (editTitleMode) {
@@ -202,18 +198,15 @@ const Activity = ({ member }) => {
               className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
               onChange={inputNewTitle}
               value={newTitle}
-              ref={titleInput}
             />
           )}
           {adminFlag && (
-            <>
-              <button
-                className="text-xs text-gray-500 underline inline-block ml-2 align-top"
-                onClick={editTitle}
-              >
-                {editTitleMode ? '확인' : '수정'}
-              </button>
-            </>
+            <button
+              className="text-xs text-gray-500 underline inline-block ml-2 align-top"
+              onClick={editTitle}
+            >
+              {editTitleMode ? '확인' : '수정'}
+            </button>
           )}
           <div className="px-2 lg:px-4 space-y-16 text-black dark:text-white">
             {activityInfo[0].subtitleImageResults.map((article, articleIdx) => (

--- a/src/page/About/Component/Excellence.jsx
+++ b/src/page/About/Component/Excellence.jsx
@@ -45,9 +45,10 @@ const temp = [
 ];
 
 const Excellence = ({ member }) => {
-  /* TODO 여기부터 지울 거 */
   const [adminFlag, setAdminFlag] = useState(false);
-  /* TODO 여기까지 지울 거 */
+  const [editTitleMode, setEditTitleMode] = useState(false);
+  const [newTitle, setNewTitle] = useState();
+  const token = member.token;
   const [excellenceInfo, setExcellenceInfo] = useState([
     {
       id: null,
@@ -75,6 +76,7 @@ const Excellence = ({ member }) => {
   /* TODO 여기부터 지울 거 */
 
   const inputRef = useRef(null);
+  const titleInput = useRef();
 
   useEffect(() => {
     if (member.token) {
@@ -131,7 +133,26 @@ const Excellence = ({ member }) => {
         setExcellenceInfo(data.list);
       }
     });
-  }, []);
+  }, [excellenceInfo]);
+
+  const editTitle = () => {
+    setNewTitle(excellenceInfo[0].title);
+    if (editTitleMode) {
+      aboutAPI
+        .changeTitle({
+          id: excellenceInfo[0].id,
+          title: newTitle,
+          type: 'excellence',
+          token: token,
+        })
+        .then((res) => {});
+    }
+    setEditTitleMode(!editTitleMode);
+  };
+
+  const inputNewTitle = (e) => {
+    setNewTitle(e.target.value);
+  };
 
   return (
     <div className="bg-mainYellow my-5">
@@ -150,9 +171,31 @@ const Excellence = ({ member }) => {
       {/* TODO 여기까지 지울 거 */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="py-6 lg:py-10  px-3 md:px-12 lg:px-16">
-          <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-white text-center drop-shadow">
-            {excellenceInfo[0].title}
-          </h2>
+          <div className="text-center">
+            {!editTitleMode && (
+              <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-white drop-shadow inline-block">
+                {excellenceInfo[0].title}
+              </h2>
+            )}
+            {editTitleMode && (
+              <input
+                className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-white text-center bg-mainYellow inline-block"
+                onChange={inputNewTitle}
+                value={newTitle}
+                ref={titleInput}
+              />
+            )}
+            {adminFlag && (
+              <>
+                <button
+                  className="text-xs text-gray-500 underline ml-2 align-top"
+                  onClick={editTitle}
+                >
+                  {editTitleMode ? '확인' : '수정'}
+                </button>
+              </>
+            )}
+          </div>
           <div className="px-2 lg:px-4 text-black">
             <div className="max-w-2xl mx-auto grid grid-cols-1 gap-8 lg:max-w-none lg:grid-cols-3">
               {excellenceInfo[0].subtitleImageResults.map(

--- a/src/page/About/Component/Excellence.jsx
+++ b/src/page/About/Component/Excellence.jsx
@@ -76,7 +76,6 @@ const Excellence = ({ member }) => {
   /* TODO 여기부터 지울 거 */
 
   const inputRef = useRef(null);
-  const titleInput = useRef();
 
   useEffect(() => {
     if (member.token) {
@@ -182,18 +181,15 @@ const Excellence = ({ member }) => {
                 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-white text-center bg-mainYellow inline-block"
                 onChange={inputNewTitle}
                 value={newTitle}
-                ref={titleInput}
               />
             )}
             {adminFlag && (
-              <>
-                <button
-                  className="text-xs text-gray-500 underline ml-2 align-top"
-                  onClick={editTitle}
-                >
-                  {editTitleMode ? '확인' : '수정'}
-                </button>
-              </>
+              <button
+                className="text-xs text-gray-500 underline ml-2 align-top"
+                onClick={editTitle}
+              >
+                {editTitleMode ? '확인' : '수정'}
+              </button>
             )}
           </div>
           <div className="px-2 lg:px-4 text-black">

--- a/src/page/About/Component/Excellence.jsx
+++ b/src/page/About/Component/Excellence.jsx
@@ -145,11 +145,7 @@ const Excellence = ({ member }) => {
           token: token,
         })
         .then((res) => {
-          aboutAPI.getExcellenceInfo().then((data) => {
-            if (data.success) {
-              setExcellenceInfo(data.list);
-            }
-          });
+          setExcellenceInfo([res.data]);
         });
     }
     setEditTitleMode(!editTitleMode);

--- a/src/page/About/Component/Excellence.jsx
+++ b/src/page/About/Component/Excellence.jsx
@@ -132,7 +132,7 @@ const Excellence = ({ member }) => {
         setExcellenceInfo(data.list);
       }
     });
-  }, [excellenceInfo]);
+  }, []);
 
   const editTitle = () => {
     setNewTitle(excellenceInfo[0].title);
@@ -144,7 +144,13 @@ const Excellence = ({ member }) => {
           type: 'excellence',
           token: token,
         })
-        .then((res) => {});
+        .then((res) => {
+          aboutAPI.getExcellenceInfo().then((data) => {
+            if (data.success) {
+              setExcellenceInfo(data.list);
+            }
+          });
+        });
     }
     setEditTitleMode(!editTitleMode);
   };

--- a/src/page/About/Component/Excellence.jsx
+++ b/src/page/About/Component/Excellence.jsx
@@ -171,17 +171,16 @@ const Excellence = ({ member }) => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="py-6 lg:py-10  px-3 md:px-12 lg:px-16">
           <div className="text-center">
-            {!editTitleMode && (
-              <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-white drop-shadow inline-block">
-                {excellenceInfo[0].title}
-              </h2>
-            )}
-            {editTitleMode && (
+            {editTitleMode ? (
               <input
                 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-white text-center bg-mainYellow inline-block"
                 onChange={inputNewTitle}
                 value={newTitle}
               />
+            ) : (
+              <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-white drop-shadow inline-block">
+                {excellenceInfo[0].title}
+              </h2>
             )}
             {adminFlag && (
               <button

--- a/src/page/About/Component/Excellence.jsx
+++ b/src/page/About/Component/Excellence.jsx
@@ -46,7 +46,7 @@ const temp = [
 
 const Excellence = ({ member }) => {
   const [adminFlag, setAdminFlag] = useState(false);
-  const [editTitleMode, setEditTitleMode] = useState(false);
+  const [isTitleEditMode, setIsTitleEditMode] = useState(false);
   const [newTitle, setNewTitle] = useState();
   const token = member.token;
   const [excellenceInfo, setExcellenceInfo] = useState([
@@ -136,7 +136,7 @@ const Excellence = ({ member }) => {
 
   const editTitle = () => {
     setNewTitle(excellenceInfo[0].title);
-    if (editTitleMode) {
+    if (isTitleEditMode) {
       aboutAPI
         .changeTitle({
           id: excellenceInfo[0].id,
@@ -148,7 +148,7 @@ const Excellence = ({ member }) => {
           setExcellenceInfo([res.data]);
         });
     }
-    setEditTitleMode(!editTitleMode);
+    setIsTitleEditMode(!isTitleEditMode);
   };
 
   const inputNewTitle = (e) => {
@@ -173,7 +173,7 @@ const Excellence = ({ member }) => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="py-6 lg:py-10  px-3 md:px-12 lg:px-16">
           <div className="text-center">
-            {editTitleMode ? (
+            {isTitleEditMode ? (
               <input
                 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-white text-center bg-mainYellow inline-block"
                 onChange={inputNewTitle}
@@ -189,7 +189,7 @@ const Excellence = ({ member }) => {
                 className="text-xs text-gray-500 underline ml-2 align-top"
                 onClick={editTitle}
               >
-                {editTitleMode ? '확인' : '수정'}
+                {isTitleEditMode ? '확인' : '수정'}
               </button>
             )}
           </div>

--- a/src/page/About/Component/History.jsx
+++ b/src/page/About/Component/History.jsx
@@ -182,17 +182,16 @@ const History = ({ member }) => {
     <div className="py-4 lg:py-5 / my-5">
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="py-6 lg:py-10 px-3 md:px-12 lg:px-16">
-          {!editTitleMode && (
-            <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow inline-block">
-              {historyInfo[0].title}
-            </h2>
-          )}
-          {editTitleMode && (
+          {editTitleMode ? (
             <input
               className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
               onChange={inputNewTitle}
               value={newTitle}
             />
+          ) : (
+            <h2 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow inline-block">
+              {historyInfo[0].title}
+            </h2>
           )}
           {adminFlag && (
             <button

--- a/src/page/About/Component/History.jsx
+++ b/src/page/About/Component/History.jsx
@@ -91,7 +91,7 @@ function classNames(...classes) {
 
 const History = ({ member }) => {
   const [adminFlag, setAdminFlag] = useState(false);
-  const [editTitleMode, setEditTitleMode] = useState(false);
+  const [isTitleEditMode, setIsTitleEditMode] = useState(false);
   const [newTitle, setNewTitle] = useState();
   const token = member.token;
   const [historyInfo, setHistoryInfo] = useState([
@@ -161,7 +161,7 @@ const History = ({ member }) => {
 
   const editTitle = () => {
     setNewTitle(historyInfo[0].title);
-    if (editTitleMode) {
+    if (isTitleEditMode) {
       aboutAPI
         .changeTitle({
           id: historyInfo[0].id,
@@ -173,7 +173,7 @@ const History = ({ member }) => {
           setHistoryInfo([res.data]);
         });
     }
-    setEditTitleMode(!editTitleMode);
+    setIsTitleEditMode(!isTitleEditMode);
   };
 
   const inputNewTitle = (e) => {
@@ -184,7 +184,7 @@ const History = ({ member }) => {
     <div className="py-4 lg:py-5 / my-5">
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="py-6 lg:py-10 px-3 md:px-12 lg:px-16">
-          {editTitleMode ? (
+          {isTitleEditMode ? (
             <input
               className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
               onChange={inputNewTitle}
@@ -200,7 +200,7 @@ const History = ({ member }) => {
               className="text-xs text-gray-500 underline inline-block ml-2 align-top"
               onClick={editTitle}
             >
-              {editTitleMode ? '확인' : '수정'}
+              {isTitleEditMode ? '확인' : '수정'}
             </button>
           )}
           <div className="px-2 lg:px-4 overflow-hidden">

--- a/src/page/About/Component/History.jsx
+++ b/src/page/About/Component/History.jsx
@@ -157,7 +157,7 @@ const History = ({ member }) => {
         setHistoryInfo(data.list);
       }
     });
-  }, [historyInfo]);
+  }, []);
 
   const editTitle = () => {
     setNewTitle(historyInfo[0].title);
@@ -169,7 +169,13 @@ const History = ({ member }) => {
           type: 'history',
           token: token,
         })
-        .then((res) => {});
+        .then((res) => {
+          aboutAPI.getHistoryInfo().then((data) => {
+            if (data.success) {
+              setHistoryInfo(data.list);
+            }
+          });
+        });
     }
     setEditTitleMode(!editTitleMode);
   };

--- a/src/page/About/Component/History.jsx
+++ b/src/page/About/Component/History.jsx
@@ -170,11 +170,7 @@ const History = ({ member }) => {
           token: token,
         })
         .then((res) => {
-          aboutAPI.getHistoryInfo().then((data) => {
-            if (data.success) {
-              setHistoryInfo(data.list);
-            }
-          });
+          setHistoryInfo([res.data]);
         });
     }
     setEditTitleMode(!editTitleMode);

--- a/src/page/About/Component/History.jsx
+++ b/src/page/About/Component/History.jsx
@@ -119,8 +119,6 @@ const History = ({ member }) => {
     },
   ]);
 
-  const titleInput = useRef();
-
   useEffect(() => {
     if (member.token) {
       utilAPI.getAuthorization({ token: member.token }).then((response) => {
@@ -194,18 +192,15 @@ const History = ({ member }) => {
               className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
               onChange={inputNewTitle}
               value={newTitle}
-              ref={titleInput}
             />
           )}
           {adminFlag && (
-            <>
-              <button
-                className="text-xs text-gray-500 underline inline-block ml-2 align-top"
-                onClick={editTitle}
-              >
-                {editTitleMode ? '확인' : '수정'}
-              </button>
-            </>
+            <button
+              className="text-xs text-gray-500 underline inline-block ml-2 align-top"
+              onClick={editTitle}
+            >
+              {editTitleMode ? '확인' : '수정'}
+            </button>
           )}
           <div className="px-2 lg:px-4 overflow-hidden">
             {historyInfo[0].subtitleImageResults.map((article, articleIdx) =>

--- a/src/page/About/Component/Intro.jsx
+++ b/src/page/About/Component/Intro.jsx
@@ -80,12 +80,7 @@ const Intro = ({ member }) => {
           token: token,
         })
         .then((res) => {
-          aboutAPI.getIntroInfo().then((data) => {
-            if (data.success) {
-              setIntroInfo(data.list);
-              console.log(data.list);
-            }
-          });
+          setIntroInfo([res.data]);
         });
     }
     setEditTitleMode(!editTitleMode);

--- a/src/page/About/Component/Intro.jsx
+++ b/src/page/About/Component/Intro.jsx
@@ -59,7 +59,7 @@ const Intro = ({ member }) => {
         );
       }
     });
-  }, [introInfo]);
+  }, []);
 
   useEffect(() => {
     if (member.token) {
@@ -79,7 +79,14 @@ const Intro = ({ member }) => {
           type: 'intro',
           token: token,
         })
-        .then((res) => {});
+        .then((res) => {
+          aboutAPI.getIntroInfo().then((data) => {
+            if (data.success) {
+              setIntroInfo(data.list);
+              console.log(data.list);
+            }
+          });
+        });
     }
     setEditTitleMode(!editTitleMode);
   };

--- a/src/page/About/Component/Intro.jsx
+++ b/src/page/About/Component/Intro.jsx
@@ -44,7 +44,6 @@ const Intro = ({ member }) => {
   ]);
 
   const [boss, setBoss] = useState('');
-  const titleInput = useRef();
 
   useEffect(() => {
     aboutAPI.getIntroInfo().then((data) => {
@@ -117,18 +116,15 @@ const Intro = ({ member }) => {
                 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
                 onChange={inputNewTitle}
                 value={newTitle}
-                ref={titleInput}
               />
             )}
             {adminFlag && (
-              <>
-                <button
-                  className="text-xs text-gray-500 underline inline-block ml-2 align-top"
-                  onClick={editTitle}
-                >
-                  {editTitleMode ? '확인' : '수정'}
-                </button>
-              </>
+              <button
+                className="text-xs text-gray-500 underline inline-block ml-2 align-top"
+                onClick={editTitle}
+              >
+                {editTitleMode ? '확인' : '수정'}
+              </button>
             )}
             <div className="md:whitespace-pre-wrap px-2 lg:px-4 text-base text-black dark:text-white">
               {content}

--- a/src/page/About/Component/Intro.jsx
+++ b/src/page/About/Component/Intro.jsx
@@ -106,17 +106,16 @@ const Intro = ({ member }) => {
             {pageTitle}
           </h1>
           <div className="py-6 lg:py-10 px-3 md:px-12 lg:px-16">
-            {!editTitleMode && (
-              <h2 className="pb-6 lg:pb-10 text-2xl w-fit font-extrabold tracking-tight text-black dark:text-mainYellow inline-block">
-                {introInfo[0].title}
-              </h2>
-            )}
-            {editTitleMode && (
+            {editTitleMode ? (
               <input
                 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
                 onChange={inputNewTitle}
                 value={newTitle}
               />
+            ) : (
+              <h2 className="pb-6 lg:pb-10 text-2xl w-fit font-extrabold tracking-tight text-black dark:text-mainYellow inline-block">
+                {introInfo[0].title}
+              </h2>
             )}
             {adminFlag && (
               <button

--- a/src/page/About/Component/Intro.jsx
+++ b/src/page/About/Component/Intro.jsx
@@ -15,7 +15,7 @@ function classNames(...classes) {
 const Intro = ({ member }) => {
   // 9번 추가
   const [adminFlag, setAdminFlag] = useState(false);
-  const [editTitleMode, setEditTitleMode] = useState(false);
+  const [isTitleEditMode, setIsTitleEditMode] = useState(false);
   const [newTitle, setNewTitle] = useState();
   const token = member.token;
   const [introInfo, setIntroInfo] = useState([
@@ -71,7 +71,7 @@ const Intro = ({ member }) => {
 
   const editTitle = () => {
     setNewTitle(introInfo[0].title);
-    if (editTitleMode) {
+    if (isTitleEditMode) {
       aboutAPI
         .changeTitle({
           id: introInfo[0].id,
@@ -83,7 +83,7 @@ const Intro = ({ member }) => {
           setIntroInfo([res.data]);
         });
     }
-    setEditTitleMode(!editTitleMode);
+    setIsTitleEditMode(!isTitleEditMode);
   };
 
   const inputNewTitle = (e) => {
@@ -108,7 +108,7 @@ const Intro = ({ member }) => {
             {pageTitle}
           </h1>
           <div className="py-6 lg:py-10 px-3 md:px-12 lg:px-16">
-            {editTitleMode ? (
+            {isTitleEditMode ? (
               <input
                 className="pb-6 lg:pb-10 text-2xl font-extrabold tracking-tight text-black dark:text-mainYellow dark:bg-darkPoint inline-block"
                 onChange={inputNewTitle}
@@ -124,7 +124,7 @@ const Intro = ({ member }) => {
                 className="text-xs text-gray-500 underline inline-block ml-2 align-top"
                 onClick={editTitle}
               >
-                {editTitleMode ? '확인' : '수정'}
+                {isTitleEditMode ? '확인' : '수정'}
               </button>
             )}
             <div className="md:whitespace-pre-wrap px-2 lg:px-4 text-base text-black dark:text-white">


### PR DESCRIPTION
페이지 블럭 타이틀 수정 버튼을 만들고 input을 통해 수정할 수 있습니다.
기존의 타이틀 값을 받아와서 input에 디폴트로 띄우고 ,
수정 완료 후에도 새로 저장한 타이틀 값이 페이지에  출력 되도록 했습니다.
- #288