### PR TITLE
Feature/CTF 세션 관련 버그 #266

### DIFF
--- a/src/redux/reducer/root.js
+++ b/src/redux/reducer/root.js
@@ -14,17 +14,17 @@ import reducerVote from './vote';
 const persistConfig = {
   key: 'root',
   storage,
-  // TODO : whitelist
+  whitelist: ['boardState', 'darkMode', 'member', 'ctf', 'vote'],
 };
 
 const rootReducer = combineReducers({
-  boardState: persistReducer(persistConfig, reducerBoardState),
-  darkMode: persistReducer(persistConfig, reducerDarkMode),
-  member: persistReducer(persistConfig, reducerMember),
+  boardState: reducerBoardState,
+  darkMode: reducerDarkMode,
+  member: reducerMember,
   //chat: persistReducer(persistConfig, reducerChat),
-  ctf: persistReducer(persistConfig, reducerCtf),
-  vote: persistReducer(persistConfig, reducerVote),
+  ctf: reducerCtf,
+  vote: reducerVote,
   category: reducerCategory,
 });
 
-export default rootReducer;
+export default persistReducer(persistConfig, rootReducer);

--- a/src/shared/AuthUser.jsx
+++ b/src/shared/AuthUser.jsx
@@ -21,8 +21,9 @@ const AuthUser = ({ member, signOut, children }) => {
       const reduxState = JSON.parse(
         window.localStorage.getItem('persist:root')
       );
-      const token = JSON.parse(reduxState.token ?? null);
-      if (!token) {
+      const member = JSON.parse(reduxState.member ?? null);
+      if (!member?.token) {
+        signOut();
         navigate('/signIn');
       }
     }


### PR DESCRIPTION
## 장애 현상
로그인 후 CTF contest 선택 창에서 contest 선택 시 로그인이 풀리는 문제.

ex) {memberInfo: "멋진_타우렌"} -> {ctfId: 3}
바라던 방향: ex) {memberInfo: "멋진_타우렌"} -> {memberInfo: "멋진_타우렌", ctfId: 3}
그래서 새로고침 후에 contest를 선택해서 들어가면 문제가 없었음.

## 장애 원인
새로고침을 할 때 마다 redux에 key 값이 쌓임.
쌓이는 key 값은 Homepage-Front/src/redux/reducer/root.js 파일의 combineReducers에 선언된 것들.
새로고침을 안하고 접근하면 update 해 줄 ctfId key가 없다고 판단해서 기존의 데이터를 지워버리고 ctfId를 생성함.

## 해결방법
`redux-persist` 적용하는 과정에 잘못 적용되어 발생하였으므로
[블로그 글](https://velog.io/@nemo/react-redux-persist-state) 참고하여 persist 적용할 `reducer`를 `whitelist`에 지정해주는 걸로 변경



- Close #266