### PR TITLE
Feature/주사위 6회차 실행 오류 버그 픽스 #338

### DIFF
--- a/src/page/Game/Components/Dice.jsx
+++ b/src/page/Game/Components/Dice.jsx
@@ -117,7 +117,7 @@ const DiceGame = ({ gameInfo, member, updateInfo }) => {
       alertPointLackModalRef.current.open();
       return;
     }
-    if (check) {
+    if (firstCheck && check) {
       alertCountModalRef.current.open();
       return;
     }


### PR DESCRIPTION
### 이슈번호
* https://github.com/KEEPER31337/Homepage-Front/issues/338
### 내용
* 주사위 게임 6회차 실행 시 주사위를 다시 굴릴 수 있는 3번의 기회가 적용이 안 되는 버그 해결